### PR TITLE
Apply WALL·E themed UI design

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import { useFonts, Montserrat_400Regular, Montserrat_700Bold } from '@expo-google-fonts/montserrat';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import colors from './constants/colors';
 import LoginScreen from './screens/LoginScreen';
 import RegisterScreen from './screens/RegisterScreen';
 import HomeScreen from './screens/HomeScreen';
@@ -8,9 +10,25 @@ import HomeScreen from './screens/HomeScreen';
 const Stack = createNativeStackNavigator();
 
 export default function App() {
+  const [fontsLoaded] = useFonts({
+    Montserrat_400Regular,
+    Montserrat_700Bold,
+  });
+
+  if (!fontsLoaded) {
+    return null;
+  }
+
   return (
     <NavigationContainer>
-      <Stack.Navigator initialRouteName="Login">
+      <Stack.Navigator
+        initialRouteName="Login"
+        screenOptions={{
+          headerStyle: { backgroundColor: colors.background },
+          headerTintColor: colors.text,
+          headerTitleStyle: { fontFamily: 'Montserrat_700Bold' },
+        }}
+      >
         <Stack.Screen name="Login" component={LoginScreen} />
         <Stack.Screen name="Register" component={RegisterScreen} />
         <Stack.Screen name="Home" component={HomeScreen} />

--- a/app.json
+++ b/app.json
@@ -4,11 +4,11 @@
     "slug": "wall-e-frontend",
     "version": "1.0.0",
     "orientation": "portrait",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "dark",
     "newArchEnabled": true,
     "splash": {
       "resizeMode": "contain",
-      "backgroundColor": "#ffffff"
+      "backgroundColor": "#2F2F2F"
     },
     "ios": {
       "supportsTablet": true

--- a/components/CustomButton.js
+++ b/components/CustomButton.js
@@ -2,10 +2,14 @@ import React from 'react';
 import { TouchableOpacity, Text, StyleSheet } from 'react-native';
 import colors from '../constants/colors';
 
-export default function CustomButton({ title, onPress, style }) {
+export default function CustomButton({ title, onPress, style, textStyle }) {
   return (
-    <TouchableOpacity onPress={onPress} style={[styles.button, style]}>
-      <Text style={styles.buttonText}>{title}</Text>
+    <TouchableOpacity
+      onPress={onPress}
+      style={[styles.button, style]}
+      activeOpacity={0.8}
+    >
+      <Text style={[styles.buttonText, textStyle]}>{title}</Text>
     </TouchableOpacity>
   );
 }
@@ -17,9 +21,15 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     alignItems: 'center',
     marginVertical: 6,
+    shadowColor: '#000',
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 3,
   },
   buttonText: {
-    color: '#fff',
+    color: colors.background,
     fontWeight: 'bold',
+    fontFamily: 'Montserrat',
   },
 });

--- a/components/CustomInput.js
+++ b/components/CustomInput.js
@@ -1,17 +1,27 @@
 import React from 'react';
 import { TextInput, StyleSheet } from 'react-native';
+import colors from '../constants/colors';
 
 export default function CustomInput({ style, ...props }) {
-  return <TextInput style={[styles.input, style]} {...props} />;
+  return (
+    <TextInput
+      placeholderTextColor={colors.secondary}
+      style={[styles.input, style]}
+      {...props}
+    />
+  );
 }
 
 const styles = StyleSheet.create({
   input: {
     borderWidth: 1,
-    borderColor: '#ccc',
+    borderColor: colors.secondary,
     padding: 10,
     borderRadius: 4,
     marginVertical: 6,
     width: '100%',
+    color: colors.text,
+    backgroundColor: colors.background,
+    fontFamily: 'Montserrat',
   },
 });

--- a/constants/colors.js
+++ b/constants/colors.js
@@ -1,5 +1,10 @@
 export default {
-  primary: '#0d6efd',
-  background: '#fff',
-  text: '#212529',
+  // Warm accent inspired by WALL·E's eyes / Eve's light
+  primary: '#F4C542',
+  // Main dark background with industrial feel
+  background: '#2F2F2F',
+  // Light text color for dark backgrounds
+  text: '#E5E5E5',
+  // Cooler secondary color for inactive elements
+  secondary: '#3B9C9C',
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "wall-e-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@expo-google-fonts/montserrat": "^0.3.0",
         "@react-navigation/native": "^7.1.10",
         "@react-navigation/native-stack": "^7.3.14",
         "axios": "^1.9.0",
         "expo": "~53.0.9",
+        "expo-font": "~11.5.0",
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
         "react-native": "0.79.2",
@@ -1316,6 +1318,12 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/@expo-google-fonts/montserrat": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/montserrat/-/montserrat-0.3.0.tgz",
+      "integrity": "sha512-Na/1b+J/v2rdZOZlw7x5F8codXYbvgREhzB+K0r3hkJMudEmqJKBBFAkHIRUvekJyUkZC4+owX8XPpU+dIhorA==",
+      "license": "MIT"
     },
     "node_modules/@expo/cli": {
       "version": "0.24.13",
@@ -3787,14 +3795,15 @@
       }
     },
     "node_modules/expo-font": {
-      "version": "13.3.1",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-11.5.1.tgz",
+      "integrity": "sha512-Bs4eXbxT7x6dcy2awEd6R7G7NwepZTz7gg6YXhMQWviXhFfH6GFmkCumV5dWR6vfJrBwiH/m7zPB5AEpSA1syQ==",
       "license": "MIT",
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
       "peerDependencies": {
-        "expo": "*",
-        "react": "*"
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {
@@ -3838,6 +3847,19 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo/node_modules/expo-font": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-13.3.1.tgz",
+      "integrity": "sha512-d+xrHYvSM9WB42wj8vP9OOFWyxed5R1evphfDb6zYBmC1dA9Hf89FpT7TNFtj2Bk3clTnpmVqQTCYbbA2P3CLg==",
+      "license": "MIT",
+      "dependencies": {
+        "fontfaceobserver": "^2.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "react-native": "0.79.2",
     "react-native-gesture-handler": "^2.25.0",
     "react-native-safe-area-context": "^5.4.1",
-    "react-native-screens": "^4.11.1"
+    "react-native-screens": "^4.11.1",
+    "expo-font": "~11.5.0",
+    "@expo-google-fonts/montserrat": "^0.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, Alert } from 'react-native';
+import colors from '../constants/colors';
 import CustomButton from '../components/CustomButton';
 import { getBalance } from '../services/wallet';
 import { logout } from '../services/auth';
@@ -45,13 +46,18 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     padding: 20,
+    backgroundColor: colors.background,
   },
   title: {
     fontSize: 24,
     marginBottom: 20,
+    color: colors.text,
+    fontFamily: 'Montserrat_700Bold',
   },
   balance: {
     fontSize: 32,
     marginBottom: 20,
+    color: colors.primary,
+    fontFamily: 'Montserrat_400Regular',
   },
 });

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, Alert } from 'react-native';
+import colors from '../constants/colors';
 import CustomInput from '../components/CustomInput';
 import CustomButton from '../components/CustomButton';
 import { login } from '../services/auth';
@@ -32,6 +33,7 @@ export default function LoginScreen({ navigation }) {
         title="Register"
         onPress={() => navigation.navigate('Register')}
         style={styles.link}
+        textStyle={styles.linkText}
       />
     </View>
   );
@@ -43,12 +45,19 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     padding: 20,
+    backgroundColor: colors.background,
   },
   title: {
     fontSize: 24,
     marginBottom: 20,
+    color: colors.text,
+    fontFamily: 'Montserrat_700Bold',
   },
   link: {
     backgroundColor: 'transparent',
+  },
+  linkText: {
+    color: colors.secondary,
+    fontFamily: 'Montserrat_400Regular',
   },
 });

--- a/screens/RegisterScreen.js
+++ b/screens/RegisterScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, Alert } from 'react-native';
+import colors from '../constants/colors';
 import CustomInput from '../components/CustomInput';
 import CustomButton from '../components/CustomButton';
 import { register } from '../services/auth';
@@ -44,9 +45,12 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     padding: 20,
+    backgroundColor: colors.background,
   },
   title: {
     fontSize: 24,
     marginBottom: 20,
+    color: colors.text,
+    fontFamily: 'Montserrat_700Bold',
   },
 });


### PR DESCRIPTION
## Summary
- refresh Expo theme colors with WALL·E palette
- update login, register and home screens with dark style and Montserrat font
- enhance button and input components with styling and shadows
- load Montserrat fonts with `@expo-google-fonts`
- update Expo config for dark interface

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f6084db80832e905045f9b3a9da13