### PR TITLE
Add wallet operations screens

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,6 +4,10 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import LoginScreen from './screens/LoginScreen';
 import RegisterScreen from './screens/RegisterScreen';
 import HomeScreen from './screens/HomeScreen';
+import TransactionsScreen from './screens/TransactionsScreen';
+import TransferScreen from './screens/TransferScreen';
+import TopUpScreen from './screens/TopUpScreen';
+import DebinScreen from './screens/DebinScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -14,6 +18,10 @@ export default function App() {
         <Stack.Screen name="Login" component={LoginScreen} />
         <Stack.Screen name="Register" component={RegisterScreen} />
         <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Transactions" component={TransactionsScreen} />
+        <Stack.Screen name="Transfer" component={TransferScreen} />
+        <Stack.Screen name="TopUp" component={TopUpScreen} />
+        <Stack.Screen name="Debin" component={DebinScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/screens/DebinScreen.js
+++ b/screens/DebinScreen.js
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Alert } from 'react-native';
+import CustomInput from '../components/CustomInput';
+import CustomButton from '../components/CustomButton';
+import { requestDebin } from '../services/wallet';
+
+export default function DebinScreen({ navigation }) {
+  const [amount, setAmount] = useState('');
+
+  const handleDebin = async () => {
+    const value = parseFloat(amount);
+    if (!value) {
+      Alert.alert('Error', 'Enter a valid amount');
+      return;
+    }
+    try {
+      await requestDebin(value);
+      Alert.alert('Success', 'DEBIN requested');
+      navigation.goBack();
+    } catch (e) {
+      Alert.alert('Error', e.response?.data?.message || e.message);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Request DEBIN</Text>
+      <CustomInput
+        placeholder="Amount"
+        value={amount}
+        onChangeText={setAmount}
+        keyboardType="numeric"
+      />
+      <CustomButton title="Request" onPress={handleDebin} />
+      <CustomButton
+        title="Cancel"
+        onPress={() => navigation.goBack()}
+        style={styles.link}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 20,
+  },
+  link: {
+    backgroundColor: 'transparent',
+  },
+});

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -34,6 +34,16 @@ export default function HomeScreen({ navigation }) {
       <Text style={styles.title}>Wallet Balance</Text>
       <Text style={styles.balance}>{balance !== null ? `$${balance}` : '...'}</Text>
       <CustomButton title="Refresh" onPress={fetchBalance} />
+      <CustomButton
+        title="View History"
+        onPress={() => navigation.navigate('Transactions')}
+      />
+      <CustomButton
+        title="Send Money"
+        onPress={() => navigation.navigate('Transfer')}
+      />
+      <CustomButton title="Top Up" onPress={() => navigation.navigate('TopUp')} />
+      <CustomButton title="Request DEBIN" onPress={() => navigation.navigate('Debin')} />
       <CustomButton title="Logout" onPress={handleLogout} />
     </View>
   );

--- a/screens/TopUpScreen.js
+++ b/screens/TopUpScreen.js
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Alert } from 'react-native';
+import CustomInput from '../components/CustomInput';
+import CustomButton from '../components/CustomButton';
+import { addMoneyManual } from '../services/wallet';
+
+export default function TopUpScreen({ navigation }) {
+  const [amount, setAmount] = useState('');
+  const [source, setSource] = useState('');
+
+  const handleTopup = async () => {
+    const value = parseFloat(amount);
+    if (!value) {
+      Alert.alert('Error', 'Enter a valid amount');
+      return;
+    }
+    try {
+      await addMoneyManual(value, 'BANK_ACCOUNT', source);
+      Alert.alert('Success', 'Balance added');
+      navigation.goBack();
+    } catch (e) {
+      Alert.alert('Error', e.response?.data?.message || e.message);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Load Balance</Text>
+      <CustomInput
+        placeholder="Amount"
+        value={amount}
+        onChangeText={setAmount}
+        keyboardType="numeric"
+      />
+      <CustomInput
+        placeholder="Source identifier"
+        value={source}
+        onChangeText={setSource}
+      />
+      <CustomButton title="Add" onPress={handleTopup} />
+      <CustomButton
+        title="Cancel"
+        onPress={() => navigation.goBack()}
+        style={styles.link}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 20,
+  },
+  link: {
+    backgroundColor: 'transparent',
+  },
+});

--- a/screens/TransactionsScreen.js
+++ b/screens/TransactionsScreen.js
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, StyleSheet, Alert } from 'react-native';
+import CustomButton from '../components/CustomButton';
+import { getWalletDetails } from '../services/wallet';
+
+export default function TransactionsScreen({ navigation }) {
+  const [transactions, setTransactions] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchTransactions = async () => {
+    try {
+      const data = await getWalletDetails();
+      setTransactions(data.allTransactions || []);
+    } catch (e) {
+      Alert.alert('Error', e.response?.data?.message || e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchTransactions();
+  }, []);
+
+  const renderItem = ({ item }) => (
+    <View
+      style={[
+        styles.item,
+        item.type === 'IN' ? styles.incoming : styles.outgoing,
+      ]}
+    >
+      <Text style={styles.date}>
+        {new Date(item.createdAt).toLocaleDateString()}
+      </Text>
+      <Text style={styles.desc}>{item.description}</Text>
+      <Text style={styles.amount}>
+        {item.type === 'OUT' ? '-' : '+'}${item.amount}
+      </Text>
+    </View>
+  );
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Transactions</Text>
+      <FlatList
+        data={transactions}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        ListEmptyComponent={
+          <Text>{loading ? 'Loading...' : 'No transactions'}</Text>
+        }
+      />
+      <CustomButton title="Back" onPress={() => navigation.goBack()} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+  item: {
+    padding: 12,
+    borderRadius: 4,
+    marginVertical: 6,
+  },
+  incoming: {
+    backgroundColor: '#d1e7dd',
+  },
+  outgoing: {
+    backgroundColor: '#f8d7da',
+  },
+  date: {
+    fontSize: 12,
+    color: '#555',
+  },
+  desc: {
+    fontSize: 16,
+  },
+  amount: {
+    fontWeight: 'bold',
+    textAlign: 'right',
+  },
+});

--- a/screens/TransferScreen.js
+++ b/screens/TransferScreen.js
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Alert } from 'react-native';
+import CustomInput from '../components/CustomInput';
+import CustomButton from '../components/CustomButton';
+import { p2pTransfer } from '../services/transactions';
+
+export default function TransferScreen({ navigation }) {
+  const [recipient, setRecipient] = useState('');
+  const [amount, setAmount] = useState('');
+
+  const handleTransfer = async () => {
+    const value = parseFloat(amount);
+    if (!recipient || !value) {
+      Alert.alert('Error', 'Please enter recipient and amount');
+      return;
+    }
+    try {
+      await p2pTransfer(recipient, value);
+      Alert.alert('Success', 'Transfer completed');
+      navigation.goBack();
+    } catch (e) {
+      Alert.alert('Error', e.response?.data?.message || e.message);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Send Money</Text>
+      <CustomInput
+        placeholder="Email or alias"
+        value={recipient}
+        onChangeText={setRecipient}
+      />
+      <CustomInput
+        placeholder="Amount"
+        value={amount}
+        onChangeText={setAmount}
+        keyboardType="numeric"
+      />
+      <CustomButton title="Send" onPress={handleTransfer} />
+      <CustomButton
+        title="Cancel"
+        onPress={() => navigation.goBack()}
+        style={styles.link}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 20,
+  },
+  link: {
+    backgroundColor: 'transparent',
+  },
+});

--- a/services/transactions.js
+++ b/services/transactions.js
@@ -1,0 +1,14 @@
+import api from './api';
+
+export const p2pTransfer = async (recipientIdentifier, amount) => {
+  const res = await api.post('/transactions/p2p', {
+    recipientIdentifier,
+    amount,
+  });
+  return res.data;
+};
+
+export const getAll = async () => {
+  const res = await api.get('/transactions');
+  return res.data;
+};

--- a/services/wallet.js
+++ b/services/wallet.js
@@ -9,3 +9,21 @@ export const requestDebin = async (amount) => {
   const res = await api.post('/wallet/topup/debin', { amount });
   return res.data;
 };
+
+export const getWalletDetails = async () => {
+  const res = await api.get('/wallet');
+  return res.data;
+};
+
+export const addMoneyManual = async (
+  amount,
+  method = 'BANK_ACCOUNT',
+  sourceIdentifier,
+) => {
+  const res = await api.post('/wallet/topup/manual', {
+    amount,
+    method,
+    sourceIdentifier,
+  });
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- implement wallet operations in service layer
- add transaction, transfer, topup and debin screens
- wire up navigation and update home screen

## Testing
- `npm install`
- `npm start -- --help`


------
https://chatgpt.com/codex/tasks/task_e_683f6069e7dc832eaff08e2a3e5b28c8