### PR TITLE
Apply theme styles to new wallet screens

### DIFF
--- a/screens/DebinScreen.js
+++ b/screens/DebinScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, Alert } from 'react-native';
+import colors from '../constants/colors';
 import CustomInput from '../components/CustomInput';
 import CustomButton from '../components/CustomButton';
 import { requestDebin } from '../services/wallet';
@@ -47,10 +48,13 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     padding: 20,
+    backgroundColor: colors.background,
   },
   title: {
     fontSize: 24,
     marginBottom: 20,
+    color: colors.text,
+    fontFamily: 'Montserrat_700Bold',
   },
   link: {
     backgroundColor: 'transparent',

--- a/screens/TopUpScreen.js
+++ b/screens/TopUpScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, Alert } from 'react-native';
+import colors from '../constants/colors';
 import CustomInput from '../components/CustomInput';
 import CustomButton from '../components/CustomButton';
 import { addMoneyManual } from '../services/wallet';
@@ -53,10 +54,13 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     padding: 20,
+    backgroundColor: colors.background,
   },
   title: {
     fontSize: 24,
     marginBottom: 20,
+    color: colors.text,
+    fontFamily: 'Montserrat_700Bold',
   },
   link: {
     backgroundColor: 'transparent',

--- a/screens/TransactionsScreen.js
+++ b/screens/TransactionsScreen.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, StyleSheet, Alert } from 'react-native';
+import colors from '../constants/colors';
 import CustomButton from '../components/CustomButton';
 import { getWalletDetails } from '../services/wallet';
 
@@ -59,11 +60,14 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     padding: 20,
+    backgroundColor: colors.background,
   },
   title: {
     fontSize: 24,
     marginBottom: 10,
     textAlign: 'center',
+    color: colors.text,
+    fontFamily: 'Montserrat_700Bold',
   },
   item: {
     padding: 12,
@@ -78,13 +82,18 @@ const styles = StyleSheet.create({
   },
   date: {
     fontSize: 12,
-    color: '#555',
+    color: colors.secondary,
+    fontFamily: 'Montserrat_400Regular',
   },
   desc: {
     fontSize: 16,
+    color: colors.text,
+    fontFamily: 'Montserrat_400Regular',
   },
   amount: {
     fontWeight: 'bold',
     textAlign: 'right',
+    color: colors.text,
+    fontFamily: 'Montserrat_700Bold',
   },
 });

--- a/screens/TransferScreen.js
+++ b/screens/TransferScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, Alert } from 'react-native';
+import colors from '../constants/colors';
 import CustomInput from '../components/CustomInput';
 import CustomButton from '../components/CustomButton';
 import { p2pTransfer } from '../services/transactions';
@@ -53,10 +54,13 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     padding: 20,
+    backgroundColor: colors.background,
   },
   title: {
     fontSize: 24,
     marginBottom: 20,
+    color: colors.text,
+    fontFamily: 'Montserrat_700Bold',
   },
   link: {
     backgroundColor: 'transparent',


### PR DESCRIPTION
## Summary
- update wallet operation screens to use Wall-E themed colors and fonts

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f61fe8874832eb426b6579837c4eb