### PR TITLE
Add Appium E2E test scaffold for iOS

### DIFF
--- a/components/CustomButton.tsx
+++ b/components/CustomButton.tsx
@@ -9,6 +9,7 @@ export interface CustomButtonProps {
   textStyle?: any;
   variant?: 'primary' | 'secondary' | 'outline' | 'ghost';
   size?: 'small' | 'medium' | 'large';
+  testID?: string;
 }
 export default function CustomButton({
   title,
@@ -17,6 +18,7 @@ export default function CustomButton({
   textStyle,
   variant = 'primary',
   size = 'medium',
+  testID,
 }: CustomButtonProps) {
   const getButtonStyle = () => {
     const baseStyle = [styles.button, (styles as any)[`button_${size}`]];
@@ -53,6 +55,7 @@ export default function CustomButton({
       onPress={onPress}
       style={getButtonStyle()}
       activeOpacity={0.8}
+      testID={testID}
     >
       <Text style={getTextStyle()}>{title}</Text>
     </TouchableOpacity>

--- a/e2e/wallet.e2e.ts
+++ b/e2e/wallet.e2e.ts
@@ -1,0 +1,30 @@
+import { expect, $ } from '@wdio/globals';
+
+describe('Wall-E wallet flow', () => {
+  it('registers, logs in and sends money', async () => {
+    // Navigate to register screen
+    await $('~login-create-account-button').click();
+
+    // Fill registration form
+    await $('~register-email-input').setValue('test@example.com');
+    await $('~register-password-input').setValue('test1234');
+    await $('~register-submit-button').click();
+
+    // Home screen should display balance
+    const balance = await $('~home-balance-text');
+    await balance.waitForExist({ timeout: 10000 });
+    expect(await balance.isExisting()).to.be.true;
+
+    // Send money
+    await $('~home-send-money-button').click();
+    await $('~transfer-recipient-input').setValue('alice@example.com');
+    await $('~transfer-amount-input').setValue('5');
+    await $('~transfer-submit-button').click();
+
+    // View transactions
+    await $('~home-view-history-button').click();
+    const list = await $('~transactions-list');
+    await list.waitForExist({ timeout: 10000 });
+    expect(await list.isExisting()).to.be.true;
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test:e2e": "wdio run ./wdio.conf.ts"
   },
   "dependencies": {
     "@expo-google-fonts/montserrat": "^0.3.0",
@@ -27,9 +28,17 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^22.15.29",
     "@types/react": "^19.1.6",
     "@types/react-native": "^0.72.8",
-    "typescript": "^5.8.3"
+    "@wdio/cli": "^9.15.0",
+    "@wdio/local-runner": "^9.15.0",
+    "@wdio/mocha-framework": "^9.15.0",
+    "@wdio/spec-reporter": "^9.15.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.8.3",
+    "webdriverio": "^9.15.0"
   },
   "private": true
 }

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -38,7 +38,7 @@ export default function HomeScreen({ navigation }: any) {
       {/* Balance Section */}
       <View style={styles.balanceCard}>
         <Text style={styles.balanceLabel}>Current Balance</Text>
-        <Text style={styles.balance}>{balance !== null ? `$${balance}` : '...'}</Text>
+        <Text style={styles.balance} testID="home-balance-text">{balance !== null ? `$${balance}` : '...'}</Text>
         <CustomButton 
           title="Refresh" 
           onPress={fetchBalance} 
@@ -57,6 +57,7 @@ export default function HomeScreen({ navigation }: any) {
               onPress={() => navigation.navigate('Transfer')}
               style={styles.fullWidthButton}
               size="medium"
+              testID="home-send-money-button"
             />
           </View>
           <View style={styles.buttonRow}>
@@ -73,6 +74,7 @@ export default function HomeScreen({ navigation }: any) {
               variant="outline"
               style={styles.gridButton}
               size="medium"
+              testID="home-view-history-button"
             />
           </View>
         </View>

--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -33,24 +33,28 @@ export default function LoginScreen({ navigation }: any) {
             onChangeText={setEmail}
             keyboardType="email-address"
             autoCapitalize="none"
+            testID="login-email-input"
           />
           <CustomInput
             placeholder="Password"
             value={password}
             onChangeText={setPassword}
             secureTextEntry
+            testID="login-password-input"
           />
 
           <CustomButton
             title="Sign In"
             onPress={handleLogin}
             style={styles.loginButton}
+            testID="login-submit-button"
           />
 
           <CustomButton
             title="Create Account"
             onPress={() => navigation.navigate('Register')}
             variant="ghost"
+            testID="login-create-account-button"
           />
         </View>
       </View>

--- a/screens/RegisterScreen.tsx
+++ b/screens/RegisterScreen.tsx
@@ -28,35 +28,40 @@ export default function RegisterScreen({ navigation }: any) {
         </View>
 
         <View style={styles.form}>
-          <CustomInput 
-            placeholder="Email" 
-            value={email} 
+          <CustomInput
+            placeholder="Email"
+            value={email}
             onChangeText={setEmail}
             keyboardType="email-address"
             autoCapitalize="none"
+            testID="register-email-input"
           />
           <CustomInput
             placeholder="Password"
             value={password}
             onChangeText={setPassword}
             secureTextEntry
+            testID="register-password-input"
           />
           <CustomInput
             placeholder="Alias (optional)"
             value={alias}
             onChangeText={setAlias}
+            testID="register-alias-input"
           />
           
-          <CustomButton 
-            title="Create Account" 
+          <CustomButton
+            title="Create Account"
             onPress={handleRegister}
             style={styles.registerButton}
+            testID="register-submit-button"
           />
           
           <CustomButton
             title="Back to Sign In"
             onPress={() => navigation.goBack()}
             variant="ghost"
+            testID="register-back-button"
           />
         </View>
       </View>

--- a/screens/TransactionsScreen.tsx
+++ b/screens/TransactionsScreen.tsx
@@ -87,6 +87,7 @@ export default function TransactionsScreen({ navigation }: any) {
         renderItem={renderItem}
         ListEmptyComponent={renderEmpty}
         contentContainerStyle={styles.listContainer}
+        testID="transactions-list"
         refreshControl={
           <RefreshControl
             refreshing={refreshing}

--- a/screens/TransferScreen.tsx
+++ b/screens/TransferScreen.tsx
@@ -39,6 +39,7 @@ export default function TransferScreen({ navigation }: any) {
             value={recipient}
             onChangeText={setRecipient}
             autoCapitalize="none"
+            testID="transfer-recipient-input"
           />
         </View>
 
@@ -49,19 +50,22 @@ export default function TransferScreen({ navigation }: any) {
             value={amount}
             onChangeText={setAmount}
             keyboardType="numeric"
+            testID="transfer-amount-input"
           />
         </View>
 
         <View style={styles.buttonGroup}>
-          <CustomButton 
-            title="Send Money" 
+          <CustomButton
+            title="Send Money"
             onPress={handleTransfer}
             style={styles.primaryButton}
+            testID="transfer-submit-button"
           />
           <CustomButton
             title="Cancel"
             onPress={() => navigation.goBack()}
             variant="outline"
+            testID="transfer-cancel-button"
           />
         </View>
       </View>

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -1,0 +1,30 @@
+import path from 'path';
+
+export const config = {
+    runner: 'local',
+    specs: ['./e2e/**/*.e2e.ts'],
+    maxInstances: 1,
+    port: 4723,
+    path: '/wd/hub',
+    capabilities: [{
+        platformName: 'iOS',
+        'appium:deviceName': 'iPhone 14',
+        'appium:platformVersion': '16.4',
+        'appium:automationName': 'XCUITest',
+        'appium:app': path.resolve('./ios/build/Build/Products/Debug-iphonesimulator/WallE.app'),
+    }],
+    logLevel: 'info',
+    framework: 'mocha',
+    reporters: ['spec'],
+    mochaOpts: {
+        timeout: 600000,
+    },
+    autoCompileOpts: {
+        tsNodeOpts: {
+            transpileOnly: true,
+            project: './tsconfig.json',
+        },
+    },
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- set up WebdriverIO configuration for Appium
- add wallet flow E2E test
- forward `testID` props through `CustomButton`
- instrument screens with `testID` values
- add npm script `test:e2e`

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_683f8637ce7c832eb4dc0218546906aa