### PR TITLE
Improve error handling with toast notifications

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useFonts, Montserrat_400Regular, Montserrat_700Bold } from '@expo-google-fonts/montserrat';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import Toast from 'react-native-toast-message';
 import colors from './constants/colors';
 import LoginScreen from './screens/LoginScreen';
 import RegisterScreen from './screens/RegisterScreen';
@@ -39,6 +40,7 @@ export default function App() {
         <Stack.Screen name="Transfer" component={TransferScreen} />
         <Stack.Screen name="Debin" component={DebinScreen} />
       </Stack.Navigator>
+      <Toast />
     </NavigationContainer>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-native-gesture-handler": "~2.24.0",
         "react-native-safe-area-context": "^5.4.0",
         "react-native-screens": "^4.11.1",
+        "react-native-toast-message": "^2.3.0",
         "react-native-web": "^0.20.0"
       },
       "devDependencies": {
@@ -7339,6 +7340,16 @@
         "react-native-is-edge-to-edge": "^1.1.7",
         "warn-once": "^0.1.0"
       },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-toast-message": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-toast-message/-/react-native-toast-message-2.3.0.tgz",
+      "integrity": "sha512-d7LldTK1ei1Bl7RFhoOYw8hVQ4oKPQHORYI//xR9Pyz3HxSlFlvQbueE5X3KLoemRRgBrOUg3zY6DxXnxrVLRg==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-native-gesture-handler": "~2.24.0",
     "react-native-safe-area-context": "^5.4.0",
     "react-native-screens": "^4.11.1",
+    "react-native-toast-message": "^2.3.0",
     "react-native-web": "^0.20.0"
   },
   "devDependencies": {

--- a/screens/DebinScreen.tsx
+++ b/screens/DebinScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Alert, ScrollView } from 'react-native';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { showError, showSuccess } from '../utils/errors';
 import colors from '../constants/colors';
 import CustomInput from '../components/CustomInput';
 import CustomButton from '../components/CustomButton';
@@ -11,15 +12,15 @@ export default function DebinScreen({ navigation }: any) {
   const handleDebin = async () => {
     const value = parseFloat(amount);
     if (!value) {
-      Alert.alert('Error', 'Enter a valid amount');
+      showError('Enter a valid amount');
       return;
     }
     try {
       await requestDebin(value);
-      Alert.alert('Success', 'DEBIN requested');
+      showSuccess('DEBIN requested');
       navigation.goBack();
     } catch (e: any) {
-      Alert.alert('Error', e.response?.data?.message || e.message);
+      showError(e.response?.data?.message || e.message);
     }
   };
 

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react';
-import { View, Text, StyleSheet, Alert, ScrollView } from 'react-native';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { showError } from '../utils/errors';
 import { useFocusEffect } from '@react-navigation/native';
 import colors from '../constants/colors';
 import CustomButton from '../components/CustomButton';
@@ -14,7 +15,7 @@ export default function HomeScreen({ navigation }: any) {
       const data = await getBalance();
       setBalance(data.balance);
     } catch (e: any) {
-      Alert.alert('Error', e.response?.data?.message || e.message);
+      showError(e.response?.data?.message || e.message);
     }
   }, []);
 
@@ -29,7 +30,7 @@ export default function HomeScreen({ navigation }: any) {
       await logout();
       navigation.replace('Login');
     } catch (e: any) {
-      Alert.alert('Logout failed', e.response?.data?.message || e.message);
+      showError(e.response?.data?.message || e.message, 'Logout failed');
     }
   };
 

--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Alert } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
+import { showError } from '../utils/errors';
 import colors from '../constants/colors';
 import CustomInput from '../components/CustomInput';
 import CustomButton from '../components/CustomButton';
@@ -14,7 +15,7 @@ export default function LoginScreen({ navigation }: any) {
       await login(email, password);
       navigation.replace('Home');
     } catch (e: any) {
-      Alert.alert('Login failed', e.response?.data?.message || e.message);
+      showError(e.response?.data?.message || e.message, 'Login failed');
     }
   };
 

--- a/screens/RegisterScreen.tsx
+++ b/screens/RegisterScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Alert } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
+import { showError } from '../utils/errors';
 import colors from '../constants/colors';
 import CustomInput from '../components/CustomInput';
 import CustomButton from '../components/CustomButton';
@@ -15,7 +16,10 @@ export default function RegisterScreen({ navigation }: any) {
       await register(email, password, alias || undefined);
       navigation.replace('Home');
     } catch (e: any) {
-      Alert.alert('Registration failed', e.response?.data?.message || e.message);
+      showError(
+        e.response?.data?.message || e.message,
+        'Registration failed'
+      );
     }
   };
 

--- a/screens/TransactionsScreen.tsx
+++ b/screens/TransactionsScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, FlatList, StyleSheet, Alert, RefreshControl } from 'react-native';
+import { View, Text, FlatList, StyleSheet, RefreshControl } from 'react-native';
+import { showError } from '../utils/errors';
 import colors from '../constants/colors';
 import CustomButton from '../components/CustomButton';
 import { getWalletDetails } from '../services/wallet';
@@ -14,7 +15,7 @@ export default function TransactionsScreen({ navigation }: any) {
       const data = await getWalletDetails();
       setTransactions(data.allTransactions || []);
     } catch (e: any) {
-      Alert.alert('Error', e.response?.data?.message || e.message);
+      showError(e.response?.data?.message || e.message);
     } finally {
       setLoading(false);
       setRefreshing(false);

--- a/screens/TransferScreen.tsx
+++ b/screens/TransferScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Alert, ScrollView } from 'react-native';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { showError, showSuccess } from '../utils/errors';
 import colors from '../constants/colors';
 import CustomInput from '../components/CustomInput';
 import CustomButton from '../components/CustomButton';
@@ -12,15 +13,15 @@ export default function TransferScreen({ navigation }: any) {
   const handleTransfer = async () => {
     const value = parseFloat(amount);
     if (!recipient || !value) {
-      Alert.alert('Error', 'Please enter recipient and amount');
+      showError('Please enter recipient and amount');
       return;
     }
     try {
       await p2pTransfer(recipient, value);
-      Alert.alert('Success', 'Transfer completed');
+      showSuccess('Transfer completed');
       navigation.goBack();
     } catch (e: any) {
-      Alert.alert('Error', e.response?.data?.message || e.message);
+      showError(e.response?.data?.message || e.message);
     }
   };
 

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,8 +1,19 @@
 import axios from 'axios';
+import { showError } from '../utils/errors';
 
 const api = axios.create({
   baseURL: process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3000',
   withCredentials: true,
 });
+
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const message =
+      error.response?.data?.message || error.message || 'Unexpected error';
+    showError(message);
+    return Promise.reject(error);
+  }
+);
 
 export default api;

--- a/utils/errors.ts
+++ b/utils/errors.ts
@@ -1,0 +1,19 @@
+import Toast from 'react-native-toast-message';
+
+export function showError(message: string, title = 'Error') {
+  Toast.show({
+    type: 'error',
+    text1: title,
+    text2: message,
+    position: 'bottom',
+  });
+}
+
+export function showSuccess(message: string, title = 'Success') {
+  Toast.show({
+    type: 'success',
+    text1: title,
+    text2: message,
+    position: 'bottom',
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4080,6 +4080,11 @@ react-native-screens@^4.11.1, "react-native-screens@>= 4.0.0":
     react-native-is-edge-to-edge "^1.1.7"
     warn-once "^0.1.0"
 
+react-native-toast-message@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/react-native-toast-message/-/react-native-toast-message-2.3.0.tgz"
+  integrity sha512-d7LldTK1ei1Bl7RFhoOYw8hVQ4oKPQHORYI//xR9Pyz3HxSlFlvQbueE5X3KLoemRRgBrOUg3zY6DxXnxrVLRg==
+
 react-native-web@^0.20.0:
   version "0.20.0"
   resolved "https://registry.npmjs.org/react-native-web/-/react-native-web-0.20.0.tgz"


### PR DESCRIPTION
## Summary
- install `react-native-toast-message`
- add global API error interceptor to show toast messages
- provide reusable `showError` and `showSuccess` helpers
- display toast notifications instead of blocking alerts
- render `<Toast />` in root app component

## Testing
- `npx tsc -p tsconfig.json`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f8991c1ec832ebd96bb36214e326c