### PR TITLE
Style toast notifications

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,7 @@ import { useFonts, Montserrat_400Regular, Montserrat_700Bold } from '@expo-googl
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Toast from 'react-native-toast-message';
+import { toastConfig } from './utils/toastConfig';
 import colors from './constants/colors';
 import LoginScreen from './screens/LoginScreen';
 import RegisterScreen from './screens/RegisterScreen';
@@ -40,7 +41,7 @@ export default function App() {
         <Stack.Screen name="Transfer" component={TransferScreen} />
         <Stack.Screen name="Debin" component={DebinScreen} />
       </Stack.Navigator>
-      <Toast />
+      <Toast config={toastConfig} />
     </NavigationContainer>
   );
 }

--- a/utils/toastConfig.tsx
+++ b/utils/toastConfig.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { BaseToast, ErrorToast } from 'react-native-toast-message';
+import colors from '../constants/colors';
+
+export const toastConfig = {
+  success: (props: any) => (
+    <BaseToast
+      {...props}
+      style={{ borderLeftColor: colors.success, backgroundColor: colors.surface }}
+      contentContainerStyle={{ paddingHorizontal: 16 }}
+      text1Style={{
+        fontSize: 16,
+        fontFamily: 'Montserrat_700Bold',
+        color: colors.text,
+      }}
+      text2Style={{
+        fontSize: 14,
+        fontFamily: 'Montserrat_400Regular',
+        color: colors.textSecondary,
+      }}
+    />
+  ),
+  error: (props: any) => (
+    <ErrorToast
+      {...props}
+      style={{ borderLeftColor: colors.error, backgroundColor: colors.surface }}
+      contentContainerStyle={{ paddingHorizontal: 16 }}
+      text1Style={{
+        fontSize: 16,
+        fontFamily: 'Montserrat_700Bold',
+        color: colors.text,
+      }}
+      text2Style={{
+        fontSize: 14,
+        fontFamily: 'Montserrat_400Regular',
+        color: colors.textSecondary,
+      }}
+    />
+  ),
+};


### PR DESCRIPTION
## Summary
- style toast notifications with custom config
- apply toast config in the main App

## Testing
- `npx tsc --noEmit` *(fails: tsconfig base path missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f9c520fc0832eb5b175f88169915c