### PR TITLE
Add bottom tab navigation and reposition logout

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useFonts, Montserrat_400Regular, Montserrat_700Bold } from '@expo-google-fonts/montserrat';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import Toast from 'react-native-toast-message';
 import { toastConfig } from './utils/toastConfig';
 import colors from './constants/colors';
@@ -13,6 +14,27 @@ import TransferScreen from './screens/TransferScreen';
 import DebinScreen from './screens/DebinScreen';
 
 const Stack = createNativeStackNavigator();
+const Tab = createBottomTabNavigator();
+
+function MainTabs() {
+  return (
+    <Tab.Navigator
+      screenOptions={{
+        headerStyle: { backgroundColor: colors.background },
+        headerTintColor: colors.text,
+        headerTitleStyle: { fontFamily: 'Montserrat_700Bold' },
+        tabBarStyle: { backgroundColor: colors.surface },
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.textSecondary,
+      }}
+    >
+      <Tab.Screen name="Home" component={HomeScreen} />
+      <Tab.Screen name="Transfer" component={TransferScreen} />
+      <Tab.Screen name="Debin" component={DebinScreen} />
+      <Tab.Screen name="Transactions" component={TransactionsScreen} />
+    </Tab.Navigator>
+  );
+}
 
 export default function App() {
   const [fontsLoaded] = useFonts({
@@ -36,10 +58,7 @@ export default function App() {
       >
         <Stack.Screen name="Login" component={LoginScreen} />
         <Stack.Screen name="Register" component={RegisterScreen} />
-        <Stack.Screen name="Home" component={HomeScreen} />
-        <Stack.Screen name="Transactions" component={TransactionsScreen} />
-        <Stack.Screen name="Transfer" component={TransferScreen} />
-        <Stack.Screen name="Debin" component={DebinScreen} />
+        <Stack.Screen name="Main" component={MainTabs} options={{ headerShown: false }} />
       </Stack.Navigator>
       <Toast config={toastConfig} />
     </NavigationContainer>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@expo-google-fonts/montserrat": "^0.3.0",
         "@expo/metro-runtime": "~5.0.4",
+        "@react-navigation/bottom-tabs": "^7.3.14",
         "@react-navigation/native": "^7.1.10",
         "@react-navigation/native-stack": "^7.3.14",
         "axios": "^1.9.0",
@@ -2733,6 +2734,23 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-navigation/bottom-tabs": {
+      "version": "7.3.14",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.3.14.tgz",
+      "integrity": "sha512-s2qinJggS2HYZdCOey9A+fN+bNpWeEKwiL/FjAVOTcv+uofxPWN6CtEZUZGPEjfRjis/srURBmCmpNZSI6sQ9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.4.3",
+        "color": "^4.2.3"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.1.10",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
       }
     },
     "node_modules/@react-navigation/core": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@expo-google-fonts/montserrat": "^0.3.0",
     "@expo/metro-runtime": "~5.0.4",
+    "@react-navigation/bottom-tabs": "^7.3.14",
     "@react-navigation/native": "^7.1.10",
     "@react-navigation/native-stack": "^7.3.14",
     "axios": "^1.9.0",

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -36,54 +36,56 @@ export default function HomeScreen({ navigation }: any) {
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.contentContainer}>
-      {/* Balance Section */}
-      <View style={styles.balanceCard}>
-        <Text style={styles.balanceLabel}>Current Balance</Text>
-        <Text style={styles.balance}>{balance !== null ? `$${balance}` : '...'}</Text>
-        <CustomButton 
-          title="Refresh" 
-          onPress={fetchBalance} 
-          variant="ghost" 
-          size="small"
-        />
-      </View>
+      <View>
+        {/* Balance Section */}
+        <View style={styles.balanceCard}>
+          <Text style={styles.balanceLabel}>Current Balance</Text>
+          <Text style={styles.balance}>{balance !== null ? `$${balance}` : '...'}</Text>
+          <CustomButton
+            title="Refresh"
+            onPress={fetchBalance}
+            variant="ghost"
+            size="small"
+          />
+        </View>
 
-      {/* Quick Actions */}
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Quick Actions</Text>
-        <View style={styles.buttonGrid}>
-          <View style={styles.buttonRow}>
-            <CustomButton
-              title="Send Money"
-              onPress={() => navigation.navigate('Transfer')}
-              style={styles.fullWidthButton}
-              size="medium"
-            />
-          </View>
-          <View style={styles.buttonRow}>
-            <CustomButton
-              title="Request DEBIN"
-              onPress={() => navigation.navigate('Debin')}
-              variant="outline"
-              style={styles.gridButton}
-              size="medium"
-            />
-            <CustomButton
-              title="View History"
-              onPress={() => navigation.navigate('Transactions')}
-              variant="outline"
-              style={styles.gridButton}
-              size="medium"
-            />
+        {/* Quick Actions */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Quick Actions</Text>
+          <View style={styles.buttonGrid}>
+            <View style={styles.buttonRow}>
+              <CustomButton
+                title="Send Money"
+                onPress={() => navigation.navigate('Transfer')}
+                style={styles.fullWidthButton}
+                size="medium"
+              />
+            </View>
+            <View style={styles.buttonRow}>
+              <CustomButton
+                title="Request DEBIN"
+                onPress={() => navigation.navigate('Debin')}
+                variant="outline"
+                style={styles.gridButton}
+                size="medium"
+              />
+              <CustomButton
+                title="View History"
+                onPress={() => navigation.navigate('Transactions')}
+                variant="outline"
+                style={styles.gridButton}
+                size="medium"
+              />
+            </View>
           </View>
         </View>
       </View>
 
-      {/* Settings */}
-      <View style={styles.section}>
-        <CustomButton 
-          title="Logout" 
-          onPress={handleLogout} 
+      {/* Logout */}
+      <View style={styles.logoutSection}>
+        <CustomButton
+          title="Logout"
+          onPress={handleLogout}
           variant="ghost"
           size="small"
         />
@@ -100,6 +102,8 @@ const styles = StyleSheet.create({
   contentContainer: {
     padding: 20,
     paddingBottom: 40,
+    flexGrow: 1,
+    justifyContent: 'space-between',
   },
   balanceCard: {
     backgroundColor: colors.surface,
@@ -149,5 +153,8 @@ const styles = StyleSheet.create({
   fullWidthButton: {
     flex: 1,
     width: '100%',
+  },
+  logoutSection: {
+    paddingVertical: 16,
   },
 });

--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -13,7 +13,7 @@ export default function LoginScreen({ navigation }: any) {
   const handleLogin = async () => {
     try {
       await login(email, password);
-      navigation.replace('Home');
+      navigation.replace('Main');
     } catch (e: any) {
       showError(e.response?.data?.message || e.message, 'Login failed');
     }

--- a/screens/RegisterScreen.tsx
+++ b/screens/RegisterScreen.tsx
@@ -14,7 +14,7 @@ export default function RegisterScreen({ navigation }: any) {
   const handleRegister = async () => {
     try {
       await register(email, password, alias || undefined);
-      navigation.replace('Home');
+      navigation.replace('Main');
     } catch (e: any) {
       showError(
         e.response?.data?.message || e.message,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1397,6 +1397,14 @@
     invariant "^2.2.4"
     nullthrows "^1.1.1"
 
+"@react-navigation/bottom-tabs@^7.3.14":
+  version "7.3.14"
+  resolved "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.3.14.tgz"
+  integrity sha512-s2qinJggS2HYZdCOey9A+fN+bNpWeEKwiL/FjAVOTcv+uofxPWN6CtEZUZGPEjfRjis/srURBmCmpNZSI6sQ9Q==
+  dependencies:
+    "@react-navigation/elements" "^2.4.3"
+    color "^4.2.3"
+
 "@react-navigation/core@^7.10.0":
   version "7.10.0"
   resolved "https://registry.npmjs.org/@react-navigation/core/-/core-7.10.0.tgz"
@@ -3202,6 +3210,51 @@ lightningcss-darwin-arm64@1.27.0:
   version "1.27.0"
   resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.27.0.tgz"
   integrity sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==
+
+lightningcss-darwin-x64@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.27.0.tgz"
+  integrity sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg==
+
+lightningcss-freebsd-x64@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.27.0.tgz"
+  integrity sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==
+
+lightningcss-linux-arm-gnueabihf@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.27.0.tgz"
+  integrity sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA==
+
+lightningcss-linux-arm64-gnu@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.27.0.tgz"
+  integrity sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==
+
+lightningcss-linux-arm64-musl@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.27.0.tgz"
+  integrity sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==
+
+lightningcss-linux-x64-gnu@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.27.0.tgz"
+  integrity sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==
+
+lightningcss-linux-x64-musl@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.27.0.tgz"
+  integrity sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==
+
+lightningcss-win32-arm64-msvc@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.27.0.tgz"
+  integrity sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==
+
+lightningcss-win32-x64-msvc@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.27.0.tgz"
+  integrity sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw==
 
 lightningcss@~1.27.0:
   version "1.27.0"


### PR DESCRIPTION
## Summary
- add `@react-navigation/bottom-tabs` for tabbed navigation
- implement `MainTabs` with Home, Transfer, Debin and Transactions screens
- update login and register to navigate to new tab navigator
- move logout button to bottom of home screen

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_683f9eb3dab0832e83a96634b51ab3b8