### PR TITLE
Add success toasts for auth operations

### DIFF
--- a/screens/DebinScreen.tsx
+++ b/screens/DebinScreen.tsx
@@ -17,7 +17,7 @@ export default function DebinScreen({ navigation }: any) {
     }
     try {
       await requestDebin(value);
-      showSuccess('DEBIN requested');
+      showSuccess('DEBIN received');
       navigation.goBack();
     } catch (e: any) {
       showError(e.response?.data?.message || e.message);

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView } from 'react-native';
-import { showError } from '../utils/errors';
+import { showError, showSuccess } from '../utils/errors';
 import { useFocusEffect } from '@react-navigation/native';
 import colors from '../constants/colors';
 import CustomButton from '../components/CustomButton';
@@ -28,6 +28,7 @@ export default function HomeScreen({ navigation }: any) {
   const handleLogout = async () => {
     try {
       await logout();
+      showSuccess('Logged out');
       navigation.replace('Login');
     } catch (e: any) {
       showError(e.response?.data?.message || e.message, 'Logout failed');

--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { showError } from '../utils/errors';
+import { showError, showSuccess } from '../utils/errors';
 import colors from '../constants/colors';
 import CustomInput from '../components/CustomInput';
 import CustomButton from '../components/CustomButton';
@@ -13,6 +13,7 @@ export default function LoginScreen({ navigation }: any) {
   const handleLogin = async () => {
     try {
       await login(email, password);
+      showSuccess('Logged in');
       navigation.replace('Home');
     } catch (e: any) {
       showError(e.response?.data?.message || e.message, 'Login failed');

--- a/screens/RegisterScreen.tsx
+++ b/screens/RegisterScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { showError } from '../utils/errors';
+import { showError, showSuccess } from '../utils/errors';
 import colors from '../constants/colors';
 import CustomInput from '../components/CustomInput';
 import CustomButton from '../components/CustomButton';
@@ -14,6 +14,7 @@ export default function RegisterScreen({ navigation }: any) {
   const handleRegister = async () => {
     try {
       await register(email, password, alias || undefined);
+      showSuccess('Account created');
       navigation.replace('Home');
     } catch (e: any) {
       showError(

--- a/screens/TransferScreen.tsx
+++ b/screens/TransferScreen.tsx
@@ -18,7 +18,7 @@ export default function TransferScreen({ navigation }: any) {
     }
     try {
       await p2pTransfer(recipient, value);
-      showSuccess('Transfer completed');
+      showSuccess('Money sent');
       navigation.goBack();
     } catch (e: any) {
       showError(e.response?.data?.message || e.message);


### PR DESCRIPTION
## Summary
- show success toasts on login, registration and logout
- show success for sending money and receiving a DEBIN

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: expo tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_683f9e4a6b9c832eac9b9e78a0dece0e