### PR TITLE
Add icons to bottom navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,7 @@ import { useFonts, Montserrat_400Regular, Montserrat_700Bold } from '@expo-googl
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import Toast from 'react-native-toast-message';
 import { toastConfig } from './utils/toastConfig';
 import colors from './constants/colors';
@@ -19,14 +20,34 @@ const Tab = createBottomTabNavigator();
 function MainTabs() {
   return (
     <Tab.Navigator
-      screenOptions={{
+      screenOptions={({ route }) => ({
         headerStyle: { backgroundColor: colors.background },
         headerTintColor: colors.text,
         headerTitleStyle: { fontFamily: 'Montserrat_700Bold' },
         tabBarStyle: { backgroundColor: colors.surface },
         tabBarActiveTintColor: colors.primary,
         tabBarInactiveTintColor: colors.textSecondary,
-      }}
+        tabBarIcon: ({ color, size }) => {
+          let iconName: React.ComponentProps<typeof MaterialCommunityIcons>['name'];
+          switch (route.name) {
+            case 'Home':
+              iconName = 'home';
+              break;
+            case 'Transfer':
+              iconName = 'bank-transfer';
+              break;
+            case 'Debin':
+              iconName = 'qrcode';
+              break;
+            case 'Transactions':
+              iconName = 'file-document';
+              break;
+            default:
+              iconName = 'circle';
+          }
+          return <MaterialCommunityIcons name={iconName} color={color} size={size} />;
+        },
+      })}
     >
       <Tab.Screen name="Home" component={HomeScreen} />
       <Tab.Screen name="Transfer" component={TransferScreen} />


### PR DESCRIPTION
## Summary
- show navigation icons using MaterialCommunityIcons

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: expo tsconfig not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa6d21a1c832ebc1739cd37597ddb